### PR TITLE
Fix email combining bug in Quickchain app

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>QuickChain - Email Chain Viewer</title>
-  <script type="module" crossorigin src="/QuickChain/assets/main-CCwh9kpx.js"></script>
-  <link rel="stylesheet" crossorigin href="/QuickChain/assets/main-y5bXwUu7.css">
+    <link rel="stylesheet" href="/css/styles.css">
+    <script type="module" src="/js/app.js"></script>
 </head>
 <body>
     <div class="app-container">

--- a/js/app.js
+++ b/js/app.js
@@ -145,17 +145,29 @@ class QuickChainApp {
      */
     async processFile(file) {
         try {
-            // Parse the .msg file
-            const email = await parseMsgFile(file);
+            // Parse the .msg file (returns array of emails)
+            const emails = await parseMsgFile(file);
 
-            // Add to email chain
-            const added = this.emailChain.addEmail(email);
+            // Track how many were added vs duplicates
+            let addedCount = 0;
+            let duplicateCount = 0;
 
-            if (!added) {
-                // Duplicate email, show info toast
+            // Add each email to the chain
+            for (const email of emails) {
+                const added = this.emailChain.addEmail(email);
+                if (added) {
+                    addedCount++;
+                } else {
+                    duplicateCount++;
+                }
+            }
+
+            // Show notification if there were duplicates
+            if (duplicateCount > 0) {
+                const emailWord = duplicateCount === 1 ? 'email' : 'emails';
                 toastManager.showError(
                     'Duplicate Email',
-                    `"${file.name}" contains an email that has already been added.`
+                    `"${file.name}" contained ${duplicateCount} ${emailWord} that ${duplicateCount === 1 ? 'has' : 'have'} already been added.`
                 );
             }
         } catch (error) {


### PR DESCRIPTION
This commit fixes two issues:
1. Emails from forwarded chains are now separated into individual cards
2. Emails are sorted by their original send date, not the forward date

Changes:
- Updated msgParser.js to detect and parse Outlook forwarded email chains
- Added parseForwardedChain() to extract individual emails from chain bodies
- Added extractEmailFromSection() to parse email headers from plain text
- Added parseOutlookDate() to handle Outlook's date format
- Modified parseMsgFile() to return array of emails instead of single email
- Updated app.js processFile() to handle multiple emails per .msg file
- Fixed index.html to use proper source paths instead of hardcoded build assets

Now when users drop forwarded .msg files, each email in the chain is extracted as a separate card with its original date, and all emails are sorted chronologically (earliest first, latest at bottom).