### PR TITLE
Fix toast menu cancel button functionality

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
         <header class="app-header">
             <h1>QuickChain</h1>
             <div class="header-controls">
-                <div class="commit-date">Commit date: 07:54PM on November 12, 2025</div>
+                <div class="commit-date">Commit date: 08:52PM on November 12, 2025</div>
                 <button id="clearAllBtn" class="clear-btn">Clear All</button>
             </div>
         </header>

--- a/js/toast.js
+++ b/js/toast.js
@@ -33,7 +33,7 @@ class ToastManager {
 
         // Add close button listener
         const closeBtn = toast.querySelector('.toast-close');
-        closeBtn.addEventListener('click', () => this.close(id));
+        closeBtn.addEventListener('click', () => this.closeAll());
 
         // Add to container
         this.container.appendChild(toast);


### PR DESCRIPTION
Modified the close button behavior in toast.js so that clicking any cancel button (X) will dismiss all active toast notifications instead of just the individual toast. This provides better UX when multiple duplicate email warnings appear.

Changes:
- toast.js: Changed close button to call closeAll() instead of close(id)
- index.html: Updated commit date to 08:52PM on November 12, 2025