### PR TITLE
Alternate email chain alignment for clarity

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -251,7 +251,8 @@ body {
     margin-bottom: 32px;
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08),
                 0 1px 3px rgba(0, 0, 0, 0.06);
-    transition: box-shadow 0.2s ease;
+    transition: all 0.2s ease;
+    max-width: 85%;
 }
 
 .file-group:last-child {
@@ -261,6 +262,17 @@ body {
 .file-group:hover {
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12),
                 0 2px 4px rgba(0, 0, 0, 0.08);
+}
+
+/* Alternating left/right alignment */
+.file-group-left {
+    margin-left: 0;
+    margin-right: auto;
+}
+
+.file-group-right {
+    margin-left: auto;
+    margin-right: 0;
 }
 
 .file-group-header {

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
         <header class="app-header">
             <h1>QuickChain</h1>
             <div class="header-controls">
-                <div class="commit-date">Commit date: 08:52PM on November 12, 2025</div>
+                <div class="commit-date">Commit date: 09:03PM on November 12, 2025</div>
                 <button id="clearAllBtn" class="clear-btn">Clear All</button>
             </div>
         </header>

--- a/js/emailChain.js
+++ b/js/emailChain.js
@@ -93,9 +93,9 @@ export class EmailChain {
         // Group emails by source file
         const groupedEmails = this.groupBySourceFile(sortedEmails);
 
-        // Render each group
-        groupedEmails.forEach(group => {
-            const groupEl = this.createFileGroupElement(group);
+        // Render each group with alternating alignment
+        groupedEmails.forEach((group, index) => {
+            const groupEl = this.createFileGroupElement(group, index);
             this.container.appendChild(groupEl);
         });
     }
@@ -131,11 +131,14 @@ export class EmailChain {
     /**
      * Create a file group element (paper sheet container)
      * @param {Object} group - Group object with sourceFile and emails array
+     * @param {number} index - Index of the group for alternating alignment
      * @returns {HTMLElement} Group element
      */
-    createFileGroupElement(group) {
+    createFileGroupElement(group, index) {
         const groupDiv = document.createElement('div');
-        groupDiv.className = 'file-group';
+        // Alternate between left and right alignment
+        const alignmentClass = index % 2 === 0 ? 'file-group-left' : 'file-group-right';
+        groupDiv.className = `file-group ${alignmentClass}`;
 
         // Add source filename header
         const headerDiv = document.createElement('div');


### PR DESCRIPTION
To make it more visually apparent when switching between email chains, file groups now alternate between left and right alignment. Even-indexed chains align left, odd-indexed chains align right. File groups are now constrained to 85% max-width to allow space for the alignment effect.