### PR TITLE
Update drop zone message for MSG files

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -225,6 +225,33 @@ body {
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
 }
 
+.drop-zone-description {
+    font-size: 13px;
+    color: var(--text-secondary);
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    max-width: 500px;
+    margin: 20px auto 0;
+    line-height: 1.5;
+}
+
+.drop-zone-privacy {
+    font-size: 12px;
+    color: var(--text-muted);
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    max-width: 500px;
+    margin: 12px auto 0;
+    line-height: 1.5;
+}
+
+.drop-zone-privacy a {
+    color: var(--accent-color);
+    text-decoration: none;
+}
+
+.drop-zone-privacy a:hover {
+    text-decoration: underline;
+}
+
 /* Email Chain */
 .email-chain {
     flex: 1;

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
         <header class="app-header">
             <h1>Email Chronology</h1>
             <div class="header-controls">
-                <div class="commit-date">Commit date: 08:28AM on November 13, 2025</div>
+                <div class="commit-date">Commit date: 10:00AM on November 13, 2025</div>
                 <button id="clearAllBtn" class="clear-btn">Clear All</button>
             </div>
         </header>
@@ -47,8 +47,10 @@
                         <path d="M7 18C4.79086 18 3 16.2091 3 14C3 11.7909 4.79086 10 7 10C7 7.23858 9.23858 5 12 5C14.7614 5 17 7.23858 17 10C19.2091 10 21 11.7909 21 14C21 16.2091 19.2091 18 17 18" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
                         <path d="M12 12V21M12 12L9 15M12 12L15 15" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
                     </svg>
-                    <p class="drop-zone-text">Drop .msg files here</p>
+                    <p class="drop-zone-text">Drag and drop .msg files here</p>
                     <p class="drop-zone-subtext">or click to browse</p>
+                    <p class="drop-zone-description">Multiple .msg files containing long email chains will be parsed into individual email messages and then merged and displayed in chronological order.</p>
+                    <p class="drop-zone-privacy">No information taken from your files. Source code may be inspected here:<br><a href="https://github.com/Mharbulous/EmailChronology" target="_blank" rel="noopener noreferrer">https://github.com/Mharbulous/EmailChronology</a></p>
                     <input type="file" id="fileInput" multiple accept=".msg" hidden>
                 </div>
             </div>


### PR DESCRIPTION
- Changed "Drop .msg files here" to "Drag and drop .msg files here"
- Added description paragraph about multi-file parsing and chronological display
- Added privacy notice with link to source code repository
- Click-to-browse functionality was already working (entire dropzone is clickable)
- Updated commit date to 10:00AM on November 13, 2025